### PR TITLE
add missing NAME info to POD

### DIFF
--- a/lib/Test/Mock/Cmd/TestUtils.pm
+++ b/lib/Test/Mock/Cmd/TestUtils.pm
@@ -61,6 +61,10 @@ sub tmp_stdout_like_rt_72976 {
 
 __END__
 
+=head1 NAME
+
+Test::Mock::Cmd - Add additional subs for test suite
+
 =head1 LICENCE AND COPYRIGHT
 
 Copyright (c) 2011 cPanel, Inc. C<< <copyright@cpanel.net>> >>. All rights reserved.

--- a/lib/Test/Mock/Cmd/TestUtils/X.pm
+++ b/lib/Test/Mock/Cmd/TestUtils/X.pm
@@ -27,6 +27,10 @@ sub i_call_backticks {
 
 __END__
 
+=head1 NAME
+
+Test::Mock::Cmd::TestUtils::X - Provide subs for test suite (X.pm)
+
 =head1 LICENCE AND COPYRIGHT
 
 Copyright (c) 2011 cPanel, Inc. C<< <copyright@cpanel.net>> >>. All rights reserved.

--- a/lib/Test/Mock/Cmd/TestUtils/Y.pm
+++ b/lib/Test/Mock/Cmd/TestUtils/Y.pm
@@ -27,6 +27,10 @@ sub i_call_backticks {
 
 __END__
 
+=head1 NAME
+
+Test::Mock::Cmd::TestUtils::Y - Provide subs for test suite (Y.pm)
+
 =head1 LICENCE AND COPYRIGHT
 
 Copyright (c) 2011 cPanel, Inc. C<< <copyright@cpanel.net>> >>. All rights reserved.


### PR DESCRIPTION
In Debian we are currently applying the following patch to
Test-Mock-Cmd.
We thought you might be interested in it too.

Description: fix whatis entry in POD
Origin: vendor
Author: mason james <mtj@kohaaloha.com>
Last-Update: 2023-01-23

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libtest-mock-cmd-perl/raw/master/debian/patches/update-pod.patch

Thanks for considering,
mason james,
Debian Perl Group